### PR TITLE
Arches + ModTer Overhaul

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,11 @@ pub fn convert(reader: bl_save::Reader<impl BufRead>) -> io::Result<ConvertRepor
             rotation_offset,
             color_override,
             direction_override,
+            microwedge_rotate,
         } in mappings
         {
             let asset_name_index = converter.asset(asset);
-            let rotation = (from.base.angle + rotation_offset) % 4;
+            let mut rotation = (from.base.angle + rotation_offset) % 4;
 
             let rotated_xy = rotate_offset((offset.0, offset.1), from.base.angle);
             let offset = (rotated_xy.0, rotated_xy.1, offset.2);
@@ -110,6 +111,47 @@ pub fn convert(reader: bl_save::Reader<impl BufRead>) -> io::Result<ConvertRepor
                 Some(color) => converter.color(color) as u32,
                 None => u32::from(from.base.color_index),
             };
+
+            // convert a vertical slope to microwedge
+            let mut direction_override = direction_override;
+            let original_dir = direction_override;
+            let mut size = size;
+            if microwedge_rotate {
+                if rotation == 0 || rotation == 2 {
+                    direction_override = Some(brs::Direction::YPositive);
+                    if rotation == 0 {
+                        let (x, z) = (size.0, size.2);
+                        size.0 = z;
+                        size.2 = x;
+                    } else {
+                        let (y, z) = (size.1, size.2);
+                        size.1 = z;
+                        size.2 = y;
+                        rotation += 1;
+                        rotation %= 4;
+                    }
+                } else {
+                    direction_override = Some(brs::Direction::XPositive);
+                    if rotation == 1 {
+                        let (y, z) = (size.1, size.2);
+                        size.1 = z;
+                        size.2 = y;
+                        rotation += 2;
+                        rotation %= 4;
+                    } else {
+                        let (x, z) = (size.0, size.2);
+                        size.0 = z;
+                        size.2 = x;
+                        rotation += 1;
+                        rotation %= 4;
+                    }
+                }
+
+                if original_dir.is_some() && original_dir.unwrap() == brs::Direction::ZNegative {
+                    rotation += 2;
+                    rotation %= 4;
+                }
+            }
 
             let brick = brs::Brick {
                 asset_name_index: asset_name_index as u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub fn convert(reader: bl_save::Reader<impl BufRead>) -> io::Result<ConvertRepor
             color_override,
             direction_override,
             microwedge_rotate,
+            inverted_modter_rotate,
         } in mappings
         {
             let asset_name_index = converter.asset(asset);
@@ -127,8 +128,7 @@ pub fn convert(reader: bl_save::Reader<impl BufRead>) -> io::Result<ConvertRepor
                         let (y, z) = (size.1, size.2);
                         size.1 = z;
                         size.2 = y;
-                        rotation += 1;
-                        rotation %= 4;
+                        rotation = (rotation + 1) % 4;
                     }
                 } else {
                     direction_override = Some(brs::Direction::XPositive);
@@ -136,21 +136,22 @@ pub fn convert(reader: bl_save::Reader<impl BufRead>) -> io::Result<ConvertRepor
                         let (y, z) = (size.1, size.2);
                         size.1 = z;
                         size.2 = y;
-                        rotation += 2;
-                        rotation %= 4;
+                        rotation = (rotation + 2) % 4;
                     } else {
                         let (x, z) = (size.0, size.2);
                         size.0 = z;
                         size.2 = x;
-                        rotation += 1;
-                        rotation %= 4;
+                        rotation = (rotation + 1) % 4;
                     }
                 }
-
                 if original_dir.is_some() && original_dir.unwrap() == brs::Direction::ZNegative {
-                    rotation += 2;
-                    rotation %= 4;
+                    rotation = (rotation + 2) % 4;
                 }
+            }
+
+            // fix odd rotation offsets on inverted ModTer
+            if inverted_modter_rotate && (rotation == 1 || rotation == 3) {
+                rotation = (rotation + 2) % 4;
             }
 
             let brick = brs::Brick {

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -292,22 +292,20 @@ lazy_static! {
             } else {
                 size * 5
             };
-            let mut mw = false;
-            let (asset, rotation, use_offset) = if captures.name("cube").is_some() {
-                ("PB_DefaultMicroBrick", 1, false)
+            let (asset, mut rotation, use_offset, mw) = if captures.name("cube").is_some() {
+                ("PB_DefaultMicroBrick", 1, false, false)
             } else if captures.name("wedge").is_some() {
-                ("PB_DefaultMicroWedge", 2, false)
+                ("PB_DefaultMicroWedge", 2, false, false)
             } else if captures.name("ramp").is_some() {
-                mw = true;
-                ("PB_DefaultMicroWedge", 3, false)
+                ("PB_DefaultMicroWedge", 3, false, true)
             } else if captures.name("cornera").is_some() {
-                ("PB_DefaultMicroWedgeTriangleCorner", 2, false)
+                ("PB_DefaultMicroWedgeTriangleCorner", 2, false, false)
             } else if captures.name("cornerb").is_some() {
-                ("PB_DefaultMicroWedgeOuterCorner", 2, false)
+                ("PB_DefaultMicroWedgeOuterCorner", 2, false, false)
             } else if captures.name("cornerc").is_some() {
-                ("PB_DefaultMicroWedgeCorner", 2, false)
+                ("PB_DefaultMicroWedgeCorner", 2, false, false)
             } else if captures.name("cornerd").is_some() {
-                ("PB_DefaultMicroWedgeInnerCorner", 2, false)
+                ("PB_DefaultMicroWedgeInnerCorner", 2, false, false)
             } else {
                 unreachable!()
             };
@@ -316,24 +314,24 @@ lazy_static! {
             } else {
                 (0, 0, 0)
             };
-            let direction = if captures.name("inv").is_some() {
-                brs::Direction::ZNegative
+            let (direction, imr) = if captures.name("inv").is_some() {
+                if captures.name("ramp").is_some() {
+                    rotation += 2;
+                    (brs::Direction::ZNegative, false)
+                } else {
+                    rotation += 3;
+                    (brs::Direction::ZNegative, true)
+                }
             } else {
-                brs::Direction::ZPositive
+                (brs::Direction::ZPositive, false)
             };
-            if mw {
-                return Some(vec![BrickDesc::new(asset)
-                .size((size * 5, size * 5, height))
-                .offset(offset)
-                .rotation_offset(rotation)
-                .microwedge_rotate()
-                .direction_override(direction)])
-            }
 
             Some(vec![BrickDesc::new(asset)
                 .size((size * 5, size * 5, height))
                 .offset(offset)
                 .rotation_offset(rotation)
+                .microwedge_rotate(mw)
+                .inverted_modter_rotate(imr)
                 .direction_override(direction)])
         },
         r"(\d+)x(\d+)x?(?P<height>\d+)? Arch(?P<up> Up)?" => |captures, _| {

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -318,5 +318,27 @@ lazy_static! {
                 .offset(offset)
                 .rotation_offset(rotation)])
         },
+        r"(\d+)x(\d+)x?(?P<height>\d+)? Arch(?P<up> Up)?" => |captures, _| {
+            let width: u32 = captures.get(1).unwrap().as_str().parse().ok()?;
+            let length: u32 = captures.get(2).unwrap().as_str().parse().ok()?;
+            let height: u32 = if captures.name("height").is_some() {
+                captures.name("height").unwrap().as_str().parse().ok()?
+            } else {
+                match length {
+                    5 => 2,
+                    8 => 3,
+                    _ => 1
+                }
+            };
+            let direction = if captures.name("up").is_some() {
+                brs::Direction::ZNegative
+            } else {
+                brs::Direction::ZPositive
+            };
+            Some(vec![BrickDesc::new("PB_DefaultArch")
+                .size((width * 5, length * 5, height * 6))
+                .direction_override(direction)
+            ])
+        },
     ];
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ pub struct BrickDesc {
     pub color_override: Option<brs::Color>,
     pub direction_override: Option<brs::Direction>,
     pub microwedge_rotate: bool,
+    pub inverted_modter_rotate: bool,
 }
 
 impl BrickDesc {
@@ -21,6 +22,7 @@ impl BrickDesc {
             color_override: None,
             direction_override: None,
             microwedge_rotate: false,
+            inverted_modter_rotate: false,
         }
     }
 
@@ -49,8 +51,13 @@ impl BrickDesc {
         self
     }
 
-    pub fn microwedge_rotate(mut self) -> Self {
-        self.microwedge_rotate = true;
+    pub fn microwedge_rotate(mut self, microwedge_rotate: bool) -> Self {
+        self.microwedge_rotate = microwedge_rotate;
+        self
+    }
+
+    pub fn inverted_modter_rotate(mut self, inverted_modter_rotate: bool) -> Self {
+        self.inverted_modter_rotate = inverted_modter_rotate;
         self
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ pub struct BrickDesc {
     pub rotation_offset: u8,
     pub color_override: Option<brs::Color>,
     pub direction_override: Option<brs::Direction>,
+    pub microwedge_rotate: bool,
 }
 
 impl BrickDesc {
@@ -19,6 +20,7 @@ impl BrickDesc {
             rotation_offset: 1,
             color_override: None,
             direction_override: None,
+            microwedge_rotate: false,
         }
     }
 
@@ -44,6 +46,11 @@ impl BrickDesc {
 
     pub fn direction_override(mut self, direction_override: brs::Direction) -> Self {
         self.direction_override = Some(direction_override);
+        self
+    }
+
+    pub fn microwedge_rotate(mut self) -> Self {
+        self.microwedge_rotate = true;
         self
     }
 }


### PR DESCRIPTION
## Arches
- add new regex pattern for arches, tested using default arch pack `Brick_Arch`
![image](https://user-images.githubusercontent.com/3935931/140437111-a95bca32-dae1-4f69-9a0b-c01673104f51.png)
## ModTer
Tested using GSF PTG
- Switch to Microbricks for more accurate shapes
- Add `microwedge_rotate` type to deal with reorienting microwedges for this usecase
- Add support for 3/4h height ModTer
![image](https://user-images.githubusercontent.com/3935931/140437049-0a76ab2f-8049-4631-ab5b-02571e18d626.png)
- Add support for inverted ModTer
![image](https://user-images.githubusercontent.com/3935931/140444226-0007d8f4-2326-49c9-9c96-c489ee6b1554.png)
